### PR TITLE
fix compile issue on OS X

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,6 +38,12 @@
 		'conditions': [
 			['OS=="mac"', {
 				'xcode_settings': {
+					'OTHER_CFLAGS': [
+						"-mmacosx-version-min=10.7",
+						"-std=c++11",
+						"-stdlib=libc++",
+						'<!@(pkg-config --cflags opencv)'
+					],
 					'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
 					'GCC_ENABLE_CPP_RTTI': '-frtti'
 				}


### PR DESCRIPTION
With this change `npm install ribs` passes on OS X Mavericks without any errors. See https://github.com/codeboost/opencv-node/pull/10/files
